### PR TITLE
Fix: 보스 체력 깎기 수정

### DIFF
--- a/EPOH/Assets/Scenes/BossRoom_MinJu.unity
+++ b/EPOH/Assets/Scenes/BossRoom_MinJu.unity
@@ -436,6 +436,7 @@ GameObject:
   - component: {fileID: 846428869}
   - component: {fileID: 846428870}
   - component: {fileID: 846428871}
+  - component: {fileID: 846428872}
   m_Layer: 7
   m_Name: Boss Running
   m_TagString: Boss
@@ -602,6 +603,19 @@ MonoBehaviour:
   boss_hp: 1000
   player_hp: 200
   hacking_point: 0
+--- !u!114 &846428872
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 846428864}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a06733a94cce544d1ad187e99f10cbe1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  boss_hp: 2000
 --- !u!1 &869420304
 GameObject:
   m_ObjectHideFlags: 0

--- a/EPOH/Assets/Scripts/Player/PlayerBossFight.cs
+++ b/EPOH/Assets/Scripts/Player/PlayerBossFight.cs
@@ -65,7 +65,7 @@ public class PlayerBossFight : MonoBehaviour
             player_controller.is_attacking = true;
             comboCount(); // ComboCount 메서드 호출
 
-            if (player_attack != null)
+            if (player_attack != null && attack_area != null)
             {
 
                 // 현재 콤보에 해당하는 공격 세기 설정
@@ -74,31 +74,35 @@ public class PlayerBossFight : MonoBehaviour
                 // 공격 범위의 공격 세기 설정
                 attack_area.SetAttackPower(current_attack_power);
 
-
-
-                boss_manager.boss_hp -= current_attack_power; // 플레이어의 공격을 받으면 boss_hp 값 공격세기만큼 감소
-                if(boss_manager.boss_hp > 0)
+                // Check if the attack area collides with the boss
+                Collider2D boss_collider = boss.GetComponent<Collider2D>();
+                if (boss_collider != null && attack_area.GetComponent<Collider2D>().IsTouching(boss_collider))
                 {
-                    Debug.Log("boss_hp 값: " + boss_manager.boss_hp);
-                }
-                //Bossmanager의 boss_hp 값이 0이 되면 더이상 감소하지 않음
-                else if(boss_manager.boss_hp <= 0)
-                {
-                    boss_manager.boss_hp = 0;
-                    Debug.Log("boss_hp 값: " + boss_manager.boss_hp);
-                }
-                
+                    Debug.Log("Boss를 공격했습니다!");
 
-                boss_manager.hacking_point += 1; // Boss에게 공격 성공시 hacking_point 값 +1
-                if(boss_manager.hacking_point != 200)
-                {
-                    Debug.Log("hacking_point 값: " + boss_manager.hacking_point);
-                }
-                else if (boss_manager.hacking_point == 200)
-                {
-                    Debug.Log("hacking_point 값: " + boss_manager.hacking_point);   
-                }
+                    boss_manager.boss_hp -= current_attack_power; // 플레이어의 공격을 받으면 boss_hp 값 공격세기만큼 감소
+                    if(boss_manager.boss_hp > 0)
+                    {
+                        Debug.Log("boss_hp 값: " + boss_manager.boss_hp);
+                    }
+                    //Bossmanager의 boss_hp 값이 0이 되면 더이상 감소하지 않음
+                    else if(boss_manager.boss_hp <= 0)
+                    {
+                        boss_manager.boss_hp = 0;
+                        Debug.Log("boss_hp 값: " + boss_manager.boss_hp);
+                    }
+                    
 
+                    boss_manager.hacking_point += 1; // Boss에게 공격 성공시 hacking_point 값 +1
+                    if(boss_manager.hacking_point != 200)
+                    {
+                        Debug.Log("hacking_point 값: " + boss_manager.hacking_point);
+                    }
+                    else if (boss_manager.hacking_point == 200)
+                    {
+                        Debug.Log("hacking_point 값: " + boss_manager.hacking_point);   
+                    }
+                }
                 
             }
 


### PR DESCRIPTION
보스가 플레이어의 공격과 충돌하지 않고도 보스의 체력이 깎이는 오류를 '보스와 플레이어의 공격이 충돌한 후 보스의 체력이 깎이게' 수정