### PR TITLE
Week 5 minju

### DIFF
--- a/EPOH/Assets/Kyoungmin/Scripts/BossHealth.cs
+++ b/EPOH/Assets/Kyoungmin/Scripts/BossHealth.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 public class BossHealth : MonoBehaviour
 {
-    public float boss_hp = 2000f; //보스의 목숨
+    public float boss_hp = 1000f; //보스의 목숨
     
     public void Damage(float power)
     {

--- a/EPOH/Assets/Kyoungmin/Scripts/BossHealth.cs
+++ b/EPOH/Assets/Kyoungmin/Scripts/BossHealth.cs
@@ -4,18 +4,34 @@ using UnityEngine;
 
 public class BossHealth : MonoBehaviour
 {
+    public BossManager boss_manager;
+    private GameObject boss;
     public float boss_hp = 1000f; //보스의 목숨
+
+    public void Start()
+    {
+        boss = GameObject.FindWithTag("Boss");
+        boss_manager = boss.GetComponent<BossManager>();
+    }
     
     public void Damage(float power)
     {
-        boss_hp -= power; //파라미터로 받은 공격 세기에 따라 목숨 감소
-        if (boss_hp <= 0)
+        // Ensure boss_hp doesn't go below 0
+        if (boss_hp > 0)
         {
-            Die();
-        }
-        else
-        { 
-            Debug.Log("[Enemy] 남은 목숨 : " + boss_hp);
+        
+            boss_hp -= power; //파라미터로 받은 공격 세기에 따라 목숨 감소
+            if (boss_hp <= 0)
+            {
+                Die();
+                boss_manager.boss_hp = boss_hp;
+            }
+            else
+            { 
+                Debug.Log("[Enemy] 남은 목숨 : " + boss_hp);
+                boss_manager.boss_hp = boss_hp;
+
+            }
         }
        
     }

--- a/EPOH/Assets/Kyoungmin/Scripts/BossHealth.cs
+++ b/EPOH/Assets/Kyoungmin/Scripts/BossHealth.cs
@@ -5,6 +5,9 @@ using UnityEngine;
 public class BossHealth : MonoBehaviour
 {
     public BossManager boss_manager;
+    public Hacking hacking;
+
+
     private GameObject boss;
     public float boss_hp = 1000f; //보스의 목숨
 
@@ -12,6 +15,7 @@ public class BossHealth : MonoBehaviour
     {
         boss = GameObject.FindWithTag("Boss");
         boss_manager = boss.GetComponent<BossManager>();
+        hacking = GetComponent<Hacking>();
     }
     
     public void Damage(float power)
@@ -25,6 +29,7 @@ public class BossHealth : MonoBehaviour
             {
                 Die();
                 boss_manager.boss_hp = boss_hp;
+                hacking.endBossBattle();
             }
             else
             { 

--- a/EPOH/Assets/Scenes/BossRoom_MinJu.unity
+++ b/EPOH/Assets/Scenes/BossRoom_MinJu.unity
@@ -434,9 +434,9 @@ GameObject:
   - component: {fileID: 846428866}
   - component: {fileID: 846428865}
   - component: {fileID: 846428869}
-  - component: {fileID: 846428870}
   - component: {fileID: 846428871}
   - component: {fileID: 846428872}
+  - component: {fileID: 846428873}
   m_Layer: 7
   m_Name: Boss Running
   m_TagString: Boss
@@ -454,7 +454,7 @@ BoxCollider2D:
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
   m_Offset: {x: 0.00000047683716, y: 0.00000011920929}
@@ -576,18 +576,6 @@ MonoBehaviour:
   delay_before_chasing: 5
   damage_effect_prefab: {fileID: 3156798883806684666, guid: e0c8242b241b92248a36968870d45c35, type: 3}
   effect_duration: 1
---- !u!114 &846428870
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 846428864}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2bed0c65e5aa8714c9225a8d35096175, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &846428871
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -615,7 +603,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a06733a94cce544d1ad187e99f10cbe1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  boss_hp: 2000
+  boss_hp: 1000
+--- !u!114 &846428873
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 846428864}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 81cb41220e038a04d874468fbc249007, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  boss_manager: {fileID: 0}
+  game_manager: {fileID: 0}
+  boss_health: {fileID: 0}
 --- !u!1 &869420304
 GameObject:
   m_ObjectHideFlags: 0
@@ -949,6 +952,26 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1288345509 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4632130523800075608, guid: 6533cbff165824e039977611200fc9d8, type: 3}
+  m_PrefabInstance: {fileID: 1601780351}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1288345531
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1288345509}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 81cb41220e038a04d874468fbc249007, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  boss_manager: {fileID: 0}
+  game_manager: {fileID: 0}
+  boss_health: {fileID: 0}
 --- !u!1 &1360401855
 GameObject:
   m_ObjectHideFlags: 0
@@ -1478,6 +1501,18 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 4632130523800075602, guid: 6533cbff165824e039977611200fc9d8, type: 3}
+      propertyPath: combo_attack_power.Array.data[0]
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 4632130523800075602, guid: 6533cbff165824e039977611200fc9d8, type: 3}
+      propertyPath: combo_attack_power.Array.data[1]
+      value: 40
+      objectReference: {fileID: 0}
+    - target: {fileID: 4632130523800075602, guid: 6533cbff165824e039977611200fc9d8, type: 3}
+      propertyPath: combo_attack_power.Array.data[2]
+      value: 100
+      objectReference: {fileID: 0}
     - target: {fileID: 4632130523800075604, guid: 6533cbff165824e039977611200fc9d8, type: 3}
       propertyPath: m_Size.x
       value: 0.9283526
@@ -1536,6 +1571,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4632130523800075611, guid: 6533cbff165824e039977611200fc9d8, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4632130524254600248, guid: 6533cbff165824e039977611200fc9d8, type: 3}
+      propertyPath: m_Layer
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []

--- a/EPOH/Assets/Scenes/MissionClear.unity
+++ b/EPOH/Assets/Scenes/MissionClear.unity
@@ -1552,8 +1552,10 @@ GameObject:
   - component: {fileID: 1771093537}
   - component: {fileID: 1771093536}
   - component: {fileID: 1771093535}
+  - component: {fileID: 1771093538}
+  - component: {fileID: 1771093539}
   m_Layer: 5
-  m_Name: Button
+  m_Name: Mission Clear Button
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1599,7 +1601,7 @@ MonoBehaviour:
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
     m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
+  m_Transition: 2
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
     m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
@@ -1610,8 +1612,8 @@ MonoBehaviour:
     m_FadeDuration: 0.1
   m_SpriteState:
     m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
-    m_SelectedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}
+    m_SelectedSprite: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}
     m_DisabledSprite: {fileID: 0}
   m_AnimationTriggers:
     m_NormalTrigger: Normal
@@ -1623,7 +1625,19 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 1771093536}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 1771093538}
+        m_TargetAssemblyTypeName: MoveToNextScene, Assembly-CSharp
+        m_MethodName: sceneChange
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!114 &1771093536
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1662,3 +1676,29 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1771093533}
   m_CullTransparentMesh: 1
+--- !u!114 &1771093538
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1771093533}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1507d79337d4ec04ca2e2ea984514143, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  next_scene_name: MainRoom
+--- !u!114 &1771093539
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1771093533}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e27b43cb5a676004bb9518bfbda93456, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  default_button: {fileID: 1771093535}

--- a/EPOH/Assets/Scripts/Hacking.cs
+++ b/EPOH/Assets/Scripts/Hacking.cs
@@ -1,25 +1,47 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 public class Hacking : MonoBehaviour
 {
     public BossManager boss_manager; // BossManager 스크립트에 대한 참조
     public GameManager game_manager; // GameManager 스크립트에 대한 참조
+    public BossHealth boss_health;
+
+    private GameObject boss;
 
     private void Start()
     {
-        // BossManager 스크립트와 GameManager 스크립트 참조
-        boss_manager = GetComponent<BossManager>();
-        game_manager = FindObjectOfType<GameManager>();
+        
+        boss = GameObject.FindWithTag("Boss");
+
+        if (boss != null)
+        {
+            // BossManager 스크립트 참조
+            boss_manager = boss.GetComponent<BossManager>();
+
+            if (boss_manager == null)
+            {
+                Debug.LogError("[Hacking] : BossManager 스크립트를 찾을 수 없습니다.");
+            }
+
+            boss_health = boss.GetComponent<BossHealth>();
+            if (boss_health == null)
+            {
+                Debug.LogError("[Hacking] : BossHealth 스크립트를 찾을 수 없습니다.");
+            }
+        }
+         else
+        {
+            Debug.LogError("[Hacking] : Boss GameObject를 찾을 수 없습니다. 'Boss' 태그를 가진 GameObject가 씬에 있는지 확인하세요.");
+        }
     }
 
-    // BossManager의 hacking_point가 100%에 다다랐을 시 보스전이 종료되는 함수
+    // BossManager의 hacking_point가 200에 다다랐을 시 보스전이 종료되는 함수
     public void checkHackingPoint()
     {
-        float hacking_percentage = (float)boss_manager.hacking_point / 100; // hacking_point의 백분율 계산
-
-        if (hacking_percentage >= 1.0f)
+        if (boss_manager.hacking_point == 200 && boss_health.boss_hp == 0)
         {
             endBossBattle();
             updateBossClearInfo();
@@ -29,7 +51,8 @@ public class Hacking : MonoBehaviour
     // 보스전 종료 함수
     private void endBossBattle()
     {
-        // 보스전 종료 관련 작업 수행
+        // hacking_point= 200 이 되고 boss_hp = 0 이 되면 임무완료 씬으로 이동
+        SceneManager.LoadScene("MissionClear");
 
         Debug.Log("보스전 종료");
     }
@@ -37,11 +60,11 @@ public class Hacking : MonoBehaviour
     // 보스 클리어 정보 갱신
     private void updateBossClearInfo()
     {
-        int boss_index = game_manager.boss_num; // 선택한 보스의 인덱스
+        int boss_index = GameManager.instance.boss_num; // 선택한 보스의 인덱스
 
         if (boss_index >= 0 && boss_index < GameManager.boss_cnt)
         {
-            game_manager.boss_clear_info[boss_index] = true; // 보스 클리어 여부 업데이트
+            GameManager.instance.boss_clear_info[boss_index] = true; // 보스 클리어 여부 업데이트
 
             Debug.Log("보스 클리어!");
             
@@ -51,9 +74,39 @@ public class Hacking : MonoBehaviour
     // hacking_point를 증가시키는 함수
     public void increaseHackingPoint(int amount)
     {
-        boss_manager.hacking_point += amount;
+        if (boss_manager != null)
+        {
+            // 해킹포인트가 200 초과하지 않음
+            if (boss_manager.hacking_point < 200)
+            {
+                boss_manager.hacking_point += amount;
+                boss_manager.hacking_point = Mathf.Min(boss_manager.hacking_point, 200);
 
-        // hacking_point 증가 후 확인
-        checkHackingPoint();
+                // hacking_point 증가 후 확인
+                checkHackingPoint();
+            }
+        }
+        else
+        {
+            Debug.LogError("[Hacking] : BossManager 컴포넌트를 찾을 수 없습니다.");
+        }
     }
+
+    // Boss 공격 성공시 hacking_point 증가
+    public void onBossHealthDecrease(float damage)
+    {
+
+        if (boss_health != null)
+        {
+            // 보스 공격 성공시마다 hacking_point 10씩 증가
+            increaseHackingPoint(10);
+            
+        }
+        else
+        {
+            Debug.LogError("[Hacking] : BossHealth 컴포넌트를 찾을 수 없습니다.");
+        }
+    }
+
+
 }

--- a/EPOH/Assets/Scripts/Hacking.cs
+++ b/EPOH/Assets/Scripts/Hacking.cs
@@ -49,7 +49,7 @@ public class Hacking : MonoBehaviour
     }
 
     // 보스전 종료 함수
-    private void endBossBattle()
+    public void endBossBattle()
     {
         // hacking_point= 200 이 되고 boss_hp = 0 이 되면 임무완료 씬으로 이동
         SceneManager.LoadScene("MissionClear");

--- a/EPOH/Assets/Scripts/Player/Attack/AttackArea.cs
+++ b/EPOH/Assets/Scripts/Player/Attack/AttackArea.cs
@@ -10,11 +10,14 @@ public class AttackArea : MonoBehaviour
     private float attack_power; //공격 세기
     private CircleCollider2D collider; //AttackArea의 collider;
     private BossHealth boss_health; //BossHealth 참조
-
+    private Hacking hacking;
+    
     void Awake()
     {
         //공격 범위 콜라이더 할당
         collider = GetComponent<CircleCollider2D>();
+
+        hacking = GetComponentInParent<Hacking>();
     }
     
     void OnTriggerEnter2D(Collider2D other)
@@ -23,6 +26,7 @@ public class AttackArea : MonoBehaviour
         if (other.CompareTag("Boss"))
         {
             Debug.Log("[AttackArea] : 충돌");
+
             //상대의 Enemy 스크립트 참조
             boss_health = other.GetComponent<BossHealth>();
             
@@ -35,6 +39,10 @@ public class AttackArea : MonoBehaviour
             {
                 Debug.LogError("[AttackArea] : BossHealth 컴포넌트를 찾을 수 없습니다.");
             }
+
+            Debug.Log("[AttackArea] :  Before calling onBossHealthDecrease");
+            // Hacking 스크립트의 onBossHealthDecrease 호출
+            hacking.onBossHealthDecrease(attack_power);
         }
         else
         {

--- a/EPOH/Assets/Scripts/Player/Attack/PlayerAttack.cs
+++ b/EPOH/Assets/Scripts/Player/Attack/PlayerAttack.cs
@@ -9,7 +9,7 @@ public class PlayerAttack : MonoBehaviour
     public bool is_attacking = false; //현재 공격 중인지
     public Animator animator; //플레이어 애니메이터 변수
     public static PlayerAttack instance;
-    public float[] combo_attack_power = { 2f, 4f, 10f }; //콤보 별 공격 세기
+    public float[] combo_attack_power = { 20f, 40f, 100f }; //콤보 별 공격 세기
     private GameObject attack_area; //공격범위 오브젝트 참조 변수
 
     void Start()

--- a/EPOH/Assets/Scripts/Player/PlayerBossFight.cs
+++ b/EPOH/Assets/Scripts/Player/PlayerBossFight.cs
@@ -18,12 +18,12 @@ public class PlayerBossFight : MonoBehaviour
     {
         player = GameObject.FindWithTag("Player"); 
         boss = GameObject.FindWithTag("Boss");
+        attack_area_object = player.transform.Find("AttackArea").gameObject;
 
         player_controller = player.GetComponent<PlayerController>();
         boss_manager = boss.GetComponent<BossManager>();
 
         player_attack = player.GetComponent<PlayerAttack>();  
-
         
         if (player_controller == null)
         {
@@ -39,7 +39,8 @@ public class PlayerBossFight : MonoBehaviour
         {
             Debug.LogError("PlayerAttack 스크립트를 찾을 수 없습니다.");
         }
-        else{
+        else 
+        {
             attack_area_object = player.transform.Find("AttackArea").gameObject;
             attack_area = attack_area_object.GetComponentInChildren<AttackArea>();
 
@@ -47,10 +48,8 @@ public class PlayerBossFight : MonoBehaviour
             {
                 Debug.LogError("AttackArea 스크립트를 찾을 수 없습니다.");
             }
-
         }
 
-        
         
         if (player == null)
         {
@@ -60,8 +59,12 @@ public class PlayerBossFight : MonoBehaviour
 
     void attackBoss()
     {
+        Debug.Log("보스 공격을 시도합니다...");
+
         if (!player_controller.is_attacking)
         {
+            Debug.Log("플레이어가 공격 중입니다...");
+
             player_controller.is_attacking = true;
             comboCount(); // ComboCount 메서드 호출
 
@@ -102,8 +105,13 @@ public class PlayerBossFight : MonoBehaviour
                     {
                         Debug.Log("hacking_point 값: " + boss_manager.hacking_point);   
                     }
+
                 }
-                
+                Debug.Log("Attack logic executed successfully!");
+            }
+            else
+            {
+                Debug.LogError("PlayerAttack 또는 AttackArea 스크립트를 찾을 수 없습니다.");
             }
 
             player_controller.is_attacking = false;
@@ -131,7 +139,7 @@ public class PlayerBossFight : MonoBehaviour
         }
 
         // 공격 버튼 처리
-        if (Input.GetButtonDown("Attack") && !player_controller.is_attacking)
+        if (Input.GetButtonDown("Attack") && player_controller.is_attacking)
         {
             comboCount();
             attackBoss();

--- a/EPOH/Assets/Scripts/SliderController.cs
+++ b/EPOH/Assets/Scripts/SliderController.cs
@@ -19,10 +19,15 @@ public class SliderController : MonoBehaviour
 
     private void updateSliderValues()
     {
+        // 최대값을 100으로 가정하여 백분율 계산
+        float max_boss_hp = 1000;
+        float max_player_hp = 200;
+        float max_hacking_point = 200;
+
         // BossManager의 변수를 읽어와서 슬라이더 값으로 설정
-        boss_hp_slider.value = boss_manager.boss_hp;
-        player_hp_slider.value = boss_manager.player_hp;
-        hacking_point_slider.value = boss_manager.hacking_point;
+        boss_hp_slider.value = boss_manager.boss_hp / max_boss_hp;
+        player_hp_slider.value = boss_manager.player_hp / max_player_hp;
+        hacking_point_slider.value = boss_manager.hacking_point / max_hacking_point;
     }
 
     void Update()


### PR DESCRIPTION
[보스 목숨값, 플레이어 콤보별 공격 세기 수정]
BossHealth.cs의 boss_hp 값을 2000f -> 1000f으로 수정
PlayerAttack.cs의 combo_attack_power 값을 2f, 4f, 100f -> 20f, 40f, 100f 으로 수정

[보스 목숨깎기, 플레이어 해킹 포인트 수정]
boss_hp와 hacking_point BossManager 스크립트에 전달

[임무완료(MissionClear) 씬으로 넘어가기 수정]
boss_hp가 0이 되고 hacking_point가 200 이 되면 임무완료(MissionClear) 씬 넘어가도록 수정

[슬라이더값 표기 오류 수정]
boss_hp, hacking_point 값이 변경됨에 따라 슬라이더 값 또한 같이 변경되도록 수정