### PR TITLE
Week 6 minju

### DIFF
--- a/EPOH/Assets/Kyoungmin/Scripts/BossHealth.cs
+++ b/EPOH/Assets/Kyoungmin/Scripts/BossHealth.cs
@@ -2,7 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class BossHealth : MonoBehaviour
+public class BossHealth :MonoBehaviour
 {
     public BossManager boss_manager;
     public Hacking hacking;
@@ -28,6 +28,7 @@ public class BossHealth : MonoBehaviour
             if (boss_hp <= 0)
             {
                 Die();
+                boss_hp = 0;
                 boss_manager.boss_hp = boss_hp;
                 hacking.checkHackingPoint();
             }

--- a/EPOH/Assets/Scenes/BossRoom_MinJu.unity
+++ b/EPOH/Assets/Scenes/BossRoom_MinJu.unity
@@ -457,7 +457,7 @@ BoxCollider2D:
   m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0.00000047683716, y: 0.00000011920929}
+  m_Offset: {x: -0.001536727, y: 0.0043679476}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
@@ -468,7 +468,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 1.0683546, y: 0.93164754}
+  m_Size: {x: 1.0650601, y: 1.0692458}
   m_EdgeRadius: 0
 --- !u!50 &846428866
 Rigidbody2D:
@@ -551,8 +551,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 846428864}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 5.8612, y: -2.6979, z: 0}
-  m_LocalScale: {x: 2.6825, y: 2.5822, z: 1}
+  m_LocalPosition: {x: 5.7746, y: -2.8914, z: 0}
+  m_LocalScale: {x: 2.4904702, y: 2.5582106, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
@@ -570,6 +570,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8bd022644227bb64399ca95d13aa2c3b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  precursor_time: 1.5
   movement_speed: 12
   start_chasing_range: 6
   distance_to_player: 0
@@ -1430,6 +1431,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 49c5fe67a7206634d82ce4f0868fcb32, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  precursor_time: 1.5
   movement_speed: 12
   start_stomping_range: 10
   distance_to_player: 0

--- a/EPOH/Assets/Scenes/MainRoom.unity
+++ b/EPOH/Assets/Scenes/MainRoom.unity
@@ -31472,6 +31472,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5492f69f317ce4ffa832b60bb8c81636, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  boss_manager: {fileID: 0}
   player_hp: 200
 --- !u!114 &1740969175
 MonoBehaviour:

--- a/EPOH/Assets/Scenes/MainRoom.unity
+++ b/EPOH/Assets/Scenes/MainRoom.unity
@@ -1554,7 +1554,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &155405045
 RectTransform:
   m_ObjectHideFlags: 0
@@ -1669,7 +1669,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
-    m_Mode: 0
+    m_Mode: 4
     m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
@@ -3121,7 +3121,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &253535022
 RectTransform:
   m_ObjectHideFlags: 0
@@ -3199,7 +3199,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &266624392
 RectTransform:
   m_ObjectHideFlags: 0
@@ -20548,7 +20548,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &755029381
 RectTransform:
   m_ObjectHideFlags: 0
@@ -23224,7 +23224,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1257212727
 RectTransform:
   m_ObjectHideFlags: 0
@@ -23573,7 +23573,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1282520712
 RectTransform:
   m_ObjectHideFlags: 0
@@ -24017,7 +24017,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1362735855
 RectTransform:
   m_ObjectHideFlags: 0
@@ -30247,7 +30247,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1579710435
 RectTransform:
   m_ObjectHideFlags: 0
@@ -30609,7 +30609,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1675114976
 RectTransform:
   m_ObjectHideFlags: 0
@@ -30968,7 +30968,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1686361913
 RectTransform:
   m_ObjectHideFlags: 0
@@ -32481,7 +32481,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1850513040
 RectTransform:
   m_ObjectHideFlags: 0
@@ -33519,7 +33519,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1927226365
 RectTransform:
   m_ObjectHideFlags: 0
@@ -33658,7 +33658,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1987799330
 RectTransform:
   m_ObjectHideFlags: 0
@@ -34142,7 +34142,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &2033163176
 RectTransform:
   m_ObjectHideFlags: 0
@@ -34355,7 +34355,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &2054884037
 RectTransform:
   m_ObjectHideFlags: 0

--- a/EPOH/Assets/Scripts/BossDog/Running/BossRunning.cs
+++ b/EPOH/Assets/Scripts/BossDog/Running/BossRunning.cs
@@ -39,7 +39,7 @@ public class BossRunning : MonoBehaviour
         GetComponent<Rigidbody2D>().gravityScale = 0;
     }
 
-    /*
+    
     void Update()
     {
         // player 및 player_controller가 초기화되어 있는지 확인
@@ -141,7 +141,7 @@ public class BossRunning : MonoBehaviour
             Destroy(damage_effect, effect_duration);
         }
     }
-    */
+    
 
     IEnumerator StartRunning()
     {

--- a/EPOH/Assets/Scripts/Hacking.cs
+++ b/EPOH/Assets/Scripts/Hacking.cs
@@ -92,6 +92,27 @@ public class Hacking : MonoBehaviour
         }
     }
 
+    // hacking_point를 감소시키는 함수
+    public void decreaseHackingPoint(int amount)
+    {
+        if (boss_manager != null)
+        {
+            // 해킹포인트가 0 보다 작지 않음
+            if (boss_manager.hacking_point > 0)
+            {
+                boss_manager.hacking_point -= amount;
+                boss_manager.hacking_point = Mathf.Max(boss_manager.hacking_point, 0);
+
+                // hacking_point 감소 후 확인
+                checkHackingPoint();
+            }
+        }
+        else
+        {
+            Debug.LogError("[Hacking] : BossManager 컴포넌트를 찾을 수 없습니다.");
+        }
+    }
+
     // Boss 공격 성공시 hacking_point 증가
     public void onBossHealthDecrease(float damage)
     {

--- a/EPOH/Assets/Scripts/Hacking.cs
+++ b/EPOH/Assets/Scripts/Hacking.cs
@@ -41,7 +41,7 @@ public class Hacking : MonoBehaviour
     // BossManager의 hacking_point가 200에 다다랐을 시 보스전이 종료되는 함수
     public void checkHackingPoint()
     {
-        if (boss_manager.hacking_point == 200 && boss_health.boss_hp == 0)
+        if (boss_manager.hacking_point == 200 && boss_manager.boss_hp <= 0)
         {
             endBossBattle();
             updateBossClearInfo();

--- a/EPOH/Assets/Scripts/Player/Attack/PlayerHealth.cs
+++ b/EPOH/Assets/Scripts/Player/Attack/PlayerHealth.cs
@@ -5,6 +5,8 @@ using UnityEngine;
 
 public class PlayerHealth : MonoBehaviour
 {
+    public BossManager boss_manager; // BossManager 스크립트 참조
+
     public float player_hp = 200; //플레이어의 목숨
     private SpriteRenderer sp; //플레이어 SpriteRenderer 참조
     private bool is_invincible; //무적 여부
@@ -13,6 +15,10 @@ public class PlayerHealth : MonoBehaviour
     {
         //SpriteRenderer 할당하기
         sp = GetComponent<SpriteRenderer>();
+
+        boss_manager = FindObjectOfType<BossManager>();
+
+        
     }
     
     //플레이어 데미지 관련
@@ -27,11 +33,15 @@ public class PlayerHealth : MonoBehaviour
 
             if (player_hp <= 0) //플레이어 목숨이 0이하라면
             {
+                player_hp = 0;
+                boss_manager.player_hp = player_hp; // BossManager의 player_hp 값 업데이트
                 Die();
             }
             else
             {
                 StartCoroutine(Invincible()); //무적시간 호출
+
+                boss_manager.player_hp = player_hp; // BossManager의 player_hp 값 업데이트
             }  
         }
     }

--- a/EPOH/Assets/Scripts/Player/Movement/PlayerController.cs
+++ b/EPOH/Assets/Scripts/Player/Movement/PlayerController.cs
@@ -10,6 +10,9 @@ using Vector2 = UnityEngine.Vector2;
 
 public class PlayerController : MonoBehaviour
 {
+    public Hacking hacking; //Hacking 스크립트 참조
+
+    
     //플레이어 좌우 이동
     private float horizontal; //수평 값
     public float player_speed = 8f; //이동 속도
@@ -68,6 +71,8 @@ public class PlayerController : MonoBehaviour
         tr = GetComponent<TrailRenderer>();
         //AttackArea 오브젝트의 컴포넌트 할당
         attack_area = transform.GetChild(0).gameObject.GetComponent<AttackArea>();
+
+        hacking = GetComponent<Hacking>();
     }
     
     void Update()
@@ -148,6 +153,12 @@ public class PlayerController : MonoBehaviour
             if (can_teleport) //순간이동을 할 수 있으면(표식을 설치한 경우)
             {
                 StartCoroutine(Teleport());
+
+                // 순간이동 시 hacking_point -10 줄어듦
+                if (hacking != null)
+                {
+                    hacking.decreaseHackingPoint(10);
+                }
             }
             else //표식을 설치하지 않은 경우
             {

--- a/EPOH/ProjectSettings/EditorBuildSettings.asset
+++ b/EPOH/ProjectSettings/EditorBuildSettings.asset
@@ -6,8 +6,8 @@ EditorBuildSettings:
   serializedVersion: 2
   m_Scenes:
   - enabled: 0
-    path: Assets/Scenes/SampleScene.unity
-    guid: 2cda990e2423bbf4892e6590ba056729
+    path: 
+    guid: 00000000000000000000000000000000
   - enabled: 1
     path: Assets/Scenes/Start.unity
     guid: 5b3ba92b4c98472498b19dfe3ad2bb14
@@ -29,13 +29,13 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/BossRoomForgetMeNot.unity
     guid: 74eb43b338363e744afb0285c831f1bd
-  - enabled: 0
+  - enabled: 1
     path: Assets/Scenes/BossRoom_MinJu.unity
     guid: 99ac07ec63b49c04cb8afdb9f5be7c11
   - enabled: 1
     path: Assets/Scenes/BossRoomPartTime.unity
     guid: 36c3ff87145a2d84e92381b45421525a
-  - enabled: 0
+  - enabled: 1
     path: Assets/Scenes/MissionClear.unity
     guid: 78c6b3de302e78d4f979014a17542878
   - enabled: 0


### PR DESCRIPTION
[캐릭터 피격시 player_hp 슬라이더 연동]
캐릭터가 피격을 받아 player_hp 값이 감소하면  player_hp 슬라이더에 연동되도록 수정

[boss_hp 값 오류 수정]
boss_hp 값이 음수가 되지 않도록 수정

[순간이동 스킬 사용시 해킹 포인트 줄어들기]
보스전에서 플레이어가 순간이동 스킬을 한번 사용할 때마다 hacking_point 가 10포인트씩 감소하는 기능 추가